### PR TITLE
:see_no_evil: feat : [redmine-phm-84] #commentt 매핑관리 gojs link 처리 - 24.07.17

### DIFF
--- a/arms/html/mapping/content-container.html
+++ b/arms/html/mapping/content-container.html
@@ -114,6 +114,18 @@
                                                                     선택되지 않음
 														        </span>
 														</div>
+														<div
+																id="select-issuetype-div"
+																class="sender"
+																style="padding-bottom: 5px; padding-top: 3px; display: none;">
+															<i class="fa fa-check"></i>
+															선택된 이슈유형 :
+															<span
+																	id="select-issuetype"
+																	style="color: #a4c6ff">
+                                                                    선택되지 않음
+														        </span>
+														</div>
 													</div>
 												</div>
 											</li>
@@ -177,7 +189,7 @@
 										<div
 												style="margin-top: 10px"
 												class="darkBack">
-											클라우드 지라의 경우 "프로젝트" 항목을 선택하시면 해당 이슈유형별 상태를 매핑할 수 있습니다.
+											클라우드 지라의 경우 "프로젝트" 항목 하위의 이슈 유형을 선택하시면 해당 이슈유형별 상태를 매핑할 수 있습니다.
 										</div>
 									</div>
 								</div>
@@ -329,8 +341,6 @@
 					<section class="widget">
 						<div class="body">
 							<div class="w-full max-w-screen-xl mx-auto">
-								<!-- * * * * * * * * * * * * * -->
-								<!-- Start of GoJS sample code -->
 								<div id="allSampleContent" class="p-4 w-full">
 									<div id="sample">
 										<div id="myDiagramDiv" style="border: solid 1px black; width: 100%; height: 500px"></div>
@@ -370,8 +380,6 @@
 									    </textarea>-->
 									</div>
 								</div>
-								<!-- * * * * * * * * * * * * * -->
-								<!--  End of GoJS sample code  -->
 							</div>
 						</div>
 					</section>

--- a/arms/js/mapping/gojs_setup.js
+++ b/arms/js/mapping/gojs_setup.js
@@ -61,12 +61,6 @@ var gojs = (function () {
                 // output port
                 $(go.Panel,
                     'Auto',
-                    { alignment: go.Spot.Right, portId: 'from', fromLinkable: true, cursor: 'pointer', click: addNodeAndLink },
-                    $(go.Shape, 'Circle', { width: 22, height: 22, fill: 'white', stroke: 'dodgerblue', strokeWidth: 3 }),
-                    $(go.Shape, 'PlusLine', { width: 11, height: 11, fill: null, stroke: 'dodgerblue', strokeWidth: 3 })
-                ),
-/*                $(go.Panel,
-                    'Auto',
                     { alignment: go.Spot.Right, portId: 'from', fromLinkable: true, cursor: 'pointer', click: (e, obj) => {
                             if (obj.part.data.category !== 'NoAdd') {
                                 addNodeAndLink(e, obj);
@@ -74,7 +68,7 @@ var gojs = (function () {
                         }},
                     $(go.Shape, 'Diamond', { width: 11, height: 11, fill: 'white', stroke: 'dodgerblue', strokeWidth: 3 }),
                     $(go.Shape, 'PlusLine', new go.Binding('visible', '', (data) => data.category !== 'NoAdd').ofObject(), { width: 11, height: 11, fill: null, stroke: 'dodgerblue', strokeWidth: 3 })
-                ),*/
+                ),
                 // input port
                 $(go.Panel,
                     'Auto',
@@ -447,8 +441,6 @@ var gojs = (function () {
         }
     }
     // end DragLinkingTool
-
-
 
     return {
         init, save, load, layout


### PR DESCRIPTION
1. ARMS 상태 카테고리 - ARMS 상태 -  ALM 상태 -> link 데이터에 의한 순서대로 표시되도록 반영
2. ARMS 상태 - ALM 상태 +버튼 -> 링크 연결만 나오도록 추가
3. mapping 데이터 기준 연결 link 추가
4. 클라우드 지라 서버 선택 시 프로젝트 - 이슈유형 jsTree 형태 출력 project 노드 클릭시 action 제거 이슈 유형 클릭 시 상태 조회 호출

추신 : 맨앞에 붙일 수 있는 구분
fix : Bug 류 처리 시 ( patch version up )
feat : 신규 기능 류 처리 시 ( minor version up )
perf : 메이저 기능 류 처리 시 ( major version up )

#close #time 1h +review SR @313devops

[ Frontend-Web::Java-Service-Tree-Framework(JSTF)::Advanc2d ] [Requirement Manage] http://www.a-rms.net
[Document] http://www.313.co.kr/confluence
[IssueTracker] http://www.313.co.kr/jira
[VersionControl] https://github.com/313devgrp
[CodeReview] http://www.313.co.kr/fecru
[CICD-Deploy] http://www.313.co.kr/jenkins
[BuildManager] http://www.313.co.kr/spinnaker
[ArtifactManager] http://www.313.co.kr/nexus
[CodeAnalysis] http://www.313.co.kr/sonar
[Docker Hub] https://hub.docker.com/u/313devgrp

[Kubernetes] http://www.313.co.kr:31380
[DockerSwarm] http://www.313.co.kr/portainer/#!/auth

[DB Admin] http://www.313.co.kr/phpmyadmin/
[S3 Admin] http://www.313.co.kr/minio/login
[MEM Admin] http://www.313.co.kr/redis/
[NoSql Index] http://www.313.co.kr/elasticsearch/_cat/indices [NoSql Node] http://www.313.co.kr/elasticsearch/_nodes?pretty=true [Kibana] http://www.313.co.kr/kibana/app/home#/
[LogStash] http://www.313.co.kr/logstash/_node/stats?pretty [ZipKin] http://www.313.co.kr/zipkin/
[ElasticHQ] http://www.313.co.kr/elastichq/#!/
[Grafana] http://www.313.co.kr/grafana

[NAS] http://www.313.co.kr:5000/webman/index.cgi
[Mail] http://www.313.co.kr/mail/
[Auth] http://www.313.co.kr/auth/
[RDP] http://www.313.co.kr/guacamole/#/