### PR TITLE
:see_no_evil: refactor : [redmine-phm-84] #comment jsTree Click 시 오류 제거, 우선순위/난이도/상태 active 반영 - 24.08.01

### DIFF
--- a/arms/js/reqAdd.js
+++ b/arms/js/reqAdd.js
@@ -388,16 +388,18 @@ function jsTreeClick(selectedNode) {
 	console.log(selectedNode);
 
 	selectedJsTreeId = selectedNode.attr("id").replace("node_", "").replace("copy_", "");
-	selectedJsTreeName = $("#req_tree").jstree("get_selected").text().trim();
+	selectedJsTreeName = $(".jstree-clicked").text().trim();
 
 	var selectRel = selectedNode.attr("rel");
 
-	if (selectedJsTreeId == 2) {
+	if (selectedJsTreeId === 2) {
 		$("#select_Req").text("루트 요구사항이 선택되었습니다.");
-	} else if (selectRel == "folder") {
+	}
+	else if (selectRel == "folder") {
 		$("#select_Req").text("(folder)" + $(".jstree-clicked").text());
-	} else {
-		$("#select_Req").text($("#req_tree").jstree("get_selected").text());
+	}
+	else {
+		$("#select_Req").text(selectedJsTreeName);
 		$("#delete_text").text(selectedJsTreeName);
 	}
 
@@ -684,7 +686,7 @@ function bindDataEditTab(ajaxData) {
 	//편집하기 - 우선순위 버튼
 	let priorityRadioButtons = $("#editview_req_priority input[type='radio']");
 	priorityRadioButtons.each(function () {
-		if (ajaxData.reqPriorityEntity && $(this).val() == ajaxData.reqPriorityEntity["c_id"]) {
+		if (ajaxData.c_req_priority_link && $(this).val() == ajaxData.c_req_priority_link) {
 			$(this).parent().addClass("active");
 			$(this).prop("checked", true);
 
@@ -695,7 +697,7 @@ function bindDataEditTab(ajaxData) {
 	//편집하기 - 난이도 버튼
 	let difficultRadioButtons = $("#editview_req_difficulty input[type='radio']");
 	difficultRadioButtons.each(function () {
-		if (ajaxData.reqDifficultyEntity && $(this).val() == ajaxData.reqDifficultyEntity["c_id"]) {
+		if (ajaxData.c_req_difficulty_link && $(this).val() == ajaxData.c_req_difficulty_link) {
 			$(this).parent().addClass("active");
 			$(this).prop("checked", true);
 
@@ -706,7 +708,7 @@ function bindDataEditTab(ajaxData) {
 	//편집하기 - 상태 버튼
 	let stateRadioButtons = $("#editview_req_state input[type='radio']");
 	stateRadioButtons.each(function () {
-		if (ajaxData.reqStateEntity && $(this).val() == ajaxData.reqStateEntity["c_id"]) {
+		if (ajaxData.c_req_state_link && $(this).val() == ajaxData.c_req_state_link) {
 			$(this).parent().addClass("active");
 			$(this).prop("checked", true);
 		} else {
@@ -860,7 +862,7 @@ function bindDataDetailTab(ajaxData) {
 	//상세보기 - 우선순위 버튼
 	let priorityRadioButtons = $("#detailview_req_priority input[type='radio']");
 	priorityRadioButtons.each(function () {
-		if (ajaxData.reqPriorityEntity && $(this).val() == ajaxData.reqPriorityEntity["c_id"]) {
+		if (ajaxData.c_req_priority_link && $(this).val() == ajaxData.c_req_priority_link) {
 			$(this).parent().addClass("active");
 			$(this).prop("checked", true);
 		} else {
@@ -870,7 +872,7 @@ function bindDataDetailTab(ajaxData) {
 	//상세보기 - 난이도 버튼
 	let difficultRadioButtons = $("#detailview_req_difficulty input[type='radio']");
 	difficultRadioButtons.each(function () {
-		if (ajaxData.reqDifficultyEntity && $(this).val() == ajaxData.reqDifficultyEntity["c_id"]) {
+		if (ajaxData.c_req_difficulty_link && $(this).val() == ajaxData.c_req_difficulty_link) {
 			$(this).parent().addClass("active");
 			$(this).prop("checked", true);
 		} else {
@@ -880,7 +882,7 @@ function bindDataDetailTab(ajaxData) {
 	//상세보기 - 상태 버튼
 	let stateRadioButtons = $("#detailview_req_state input[type='radio']");
 	stateRadioButtons.each(function () {
-		if (ajaxData.reqStateEntity && $(this).val() == ajaxData.reqStateEntity["c_id"]) {
+		if (ajaxData.c_req_state_link && $(this).val() == ajaxData.c_req_state_link) {
 			$(this).parent().addClass("active");
 			$(this).prop("checked", true);
 		} else {


### PR DESCRIPTION
1. jsTree Click 시 요구사항 이름 추가되는 현상 제거
2. 우선순위/난이도/상태 active 반영

추신 : 맨앞에 붙일 수 있는 구분
fix : Bug 류 처리 시 ( patch version up )
feat : 신규 기능 류 처리 시 ( minor version up )
perf : 메이저 기능 류 처리 시 ( major version up )

#close #time 1h +review SR @313devops

[ Frontend-Web::Java-Service-Tree-Framework(JSTF)::Advanc2d ] [Requirement Manage] http://www.a-rms.net
[Document] http://www.313.co.kr/confluence
[IssueTracker] http://www.313.co.kr/jira
[VersionControl] https://github.com/313devgrp
[CodeReview] http://www.313.co.kr/fecru
[CICD-Deploy] http://www.313.co.kr/jenkins
[BuildManager] http://www.313.co.kr/spinnaker
[ArtifactManager] http://www.313.co.kr/nexus
[CodeAnalysis] http://www.313.co.kr/sonar
[Docker Hub] https://hub.docker.com/u/313devgrp

[Kubernetes] http://www.313.co.kr:31380
[DockerSwarm] http://www.313.co.kr/portainer/#!/auth

[DB Admin] http://www.313.co.kr/phpmyadmin/
[S3 Admin] http://www.313.co.kr/minio/login
[MEM Admin] http://www.313.co.kr/redis/
[NoSql Index] http://www.313.co.kr/elasticsearch/_cat/indices [NoSql Node] http://www.313.co.kr/elasticsearch/_nodes?pretty=true [Kibana] http://www.313.co.kr/kibana/app/home#/
[LogStash] http://www.313.co.kr/logstash/_node/stats?pretty [ZipKin] http://www.313.co.kr/zipkin/
[ElasticHQ] http://www.313.co.kr/elastichq/#!/
[Grafana] http://www.313.co.kr/grafana

[NAS] http://www.313.co.kr:5000/webman/index.cgi
[Mail] http://www.313.co.kr/mail/
[Auth] http://www.313.co.kr/auth/
[RDP] http://www.313.co.kr/guacamole/#/