### PR TITLE
:see_no_evil: feat : [redmine-phm-84] #comment - 상태 더블 클릭 모달 수정 적용 - 24.08.19

### DIFF
--- a/arms/js/mapping.js
+++ b/arms/js/mapping.js
@@ -819,7 +819,7 @@ function update_radio_buttons(container_selector, value) {
 
     let radio_buttons = $(container_selector + " input[type='radio']");
     radio_buttons.each(function () {
-        if (value && $(this).val() === value) {
+        if (value && $(this).val() == value) {
             $(this).parent().addClass("active");
             $(this).prop("checked", true);
         }
@@ -856,24 +856,8 @@ function save_req_state_btn_click() {
                 200: function () {
                     jSuccess('"' + state_name + '"' + " 상태가 생성되었습니다.");
                     $("#close_modal_popup").trigger("click");
-                    // 선택된 서버가 있을  Mapping 화면 재로드
-                    if ($("#selected_alm_server").val()) {
-                        let selected_alm_server_c_id = $("#selected_alm_server").val();
-                        let alm_server_data = alm_server_list[selected_alm_server_c_id];
-                        let alm_server_type = alm_server_data.c_jira_server_type;
 
-                        if (alm_server_type === "클라우드") {
-                            $("#cloud_project_tree").show();
-                            $("#select-project-div").show();
-                            $("#select-issuetype-div").show();
-                            build_alm_server_jstree(selected_alm_server_c_id);
-                            let data = {};
-                            gojs.load(data);
-                        }
-                        else {
-                            mapping_data_load(selected_alm_server_c_id, alm_server_type);
-                        }
-                    }
+                    init_mapping_diagram();
                 }
             }
         });
@@ -898,6 +882,8 @@ function update_req_state_btn_click() {
             .then((result) => {
                 console.log(result);
                 $("#close_modal_popup").trigger("click");
+
+                init_mapping_diagram();
             })
             .catch((error) => {
                 // 오류가 발생한 경우 처리합니다.
@@ -921,12 +907,37 @@ function delete_req_state_btn_click() {
             .then((result) => {
                 console.log(result);
                 $("#close_modal_popup").trigger("click");
+
+                init_mapping_diagram();
             })
             .catch((error) => {
                 // 오류가 발생한 경우 처리합니다.
                 console.error('Error fetching data:', error);
             });
     });
+}
+
+function init_mapping_diagram() {
+    // 선택된 서버가 있을  Mapping 화면 재로드
+    if ($("#selected_alm_server").val()) {
+        let selected_alm_server_c_id = $("#selected_alm_server").val();
+        let alm_server_data = alm_server_list[selected_alm_server_c_id];
+        let alm_server_type = alm_server_data.c_jira_server_type;
+
+        if (alm_server_type === "클라우드") {
+            $("#select-project").text("선택되지 않음");
+            $("#select-issuetype").text("선택되지 않음");
+            $("#cloud_project_tree").show();
+            $("#select-project-div").show();
+            $("#select-issuetype-div").show();
+            build_alm_server_jstree(selected_alm_server_c_id);
+            let data = {};
+            gojs.load(data);
+        }
+        else {
+            mapping_data_load(selected_alm_server_c_id, alm_server_type);
+        }
+    }
 }
 
 function update_arms_state(state_c_id, state_category_mapping_id, state_name, state_contents) {

--- a/arms/js/mapping/gojs_setup.js
+++ b/arms/js/mapping/gojs_setup.js
@@ -50,8 +50,15 @@ var gojs = (function () {
             $(go.Node,
                 { movable: false },
                 'Spot',
-                { selectionAdorned: false, textEditable: true, locationObjectName: 'BODY' },
+                { selectionAdorned: false, textEditable: false, locationObjectName: 'BODY' },
                 new go.Binding('location', 'loc', go.Point.parse).makeTwoWay(go.Point.stringify),
+                {
+                    doubleClick: (e, node) => {
+                        // 더블 클릭 시 실행할 메소드 호출
+                        console.log(node.data.c_id);
+                        popup_modal('update_popup', node.data.c_id);
+                    }
+                },
                 // the main body consists of a Rectangle surrounding the text
                 $(go.Panel,
                     'Auto',


### PR DESCRIPTION
…

Node 더블 클릭 시 상태명 변경
-> Node 더블 클릭 시 모달 창 수정 적용

추신 : 맨앞에 붙일 수 있는 구분
fix : Bug 류 처리 시 ( patch version up )
feat : 신규 기능 류 처리 시 ( minor version up )
perf : 메이저 기능 류 처리 시 ( major version up )

#close #time 1h +review SR @313devops

[ Frontend-Web::Java-Service-Tree-Framework(JSTF)::Advanc2d ] [Requirement Manage] http://www.a-rms.net
[Document] http://www.313.co.kr/confluence
[IssueTracker] http://www.313.co.kr/jira
[VersionControl] https://github.com/313devgrp
[CodeReview] http://www.313.co.kr/fecru
[CICD-Deploy] http://www.313.co.kr/jenkins
[BuildManager] http://www.313.co.kr/spinnaker
[ArtifactManager] http://www.313.co.kr/nexus
[CodeAnalysis] http://www.313.co.kr/sonar
[Docker Hub] https://hub.docker.com/u/313devgrp

[Kubernetes] http://www.313.co.kr:31380
[DockerSwarm] http://www.313.co.kr/portainer/#!/auth

[DB Admin] http://www.313.co.kr/phpmyadmin/
[S3 Admin] http://www.313.co.kr/minio/login
[MEM Admin] http://www.313.co.kr/redis/
[NoSql Index] http://www.313.co.kr/elasticsearch/_cat/indices [NoSql Node] http://www.313.co.kr/elasticsearch/_nodes?pretty=true [Kibana] http://www.313.co.kr/kibana/app/home#/
[LogStash] http://www.313.co.kr/logstash/_node/stats?pretty [ZipKin] http://www.313.co.kr/zipkin/
[ElasticHQ] http://www.313.co.kr/elastichq/#!/
[Grafana] http://www.313.co.kr/grafana

[NAS] http://www.313.co.kr:5000/webman/index.cgi
[Mail] http://www.313.co.kr/mail/
[Auth] http://www.313.co.kr/auth/
[RDP] http://www.313.co.kr/guacamole/#/